### PR TITLE
Remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
   "logo": "https://node-js-sample.herokuapp.com/node.svg",
   "keywords": ["ink"],
   "success_url": "/setup",
-  "env": {
-    "BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go.git"
-  },
   "addons": [
     "mongolab"
   ]


### PR DESCRIPTION
This is no longer required since we launched official Go support: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku
